### PR TITLE
Array.present? vs. Array.any?

### DIFF
--- a/spec/array_spec.rb
+++ b/spec/array_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'active_support/core_ext'
 
 RSpec.describe Array do
   it "value reject" do
@@ -127,6 +128,20 @@ RSpec.describe Array do
         end
       }
 
+    end
+  end
+
+  it 'present' do
+    Benchmark.ips do |x|
+      empty10k = Array.new(10_000)
+
+      x.report('present?') {
+        empty10k.present?
+      }
+      x.report('any?') {
+        empty10k.any?
+      }
+      x.compare!
     end
   end
 end


### PR DESCRIPTION
I had assumed `.any?` was worse but I wanted to see by how much.

```
Calculating -------------------------------------
            present?    39.494k i/100ms
                any?    10.770k i/100ms
-------------------------------------------------
            present?      7.107M (±18.8%) i/s -     33.135M
                any?    143.259k (± 4.7%) i/s -    721.590k

Comparison:
            present?:  7106655.4 i/s
                any?:   143258.8 i/s - 49.61x slower
```